### PR TITLE
Fix some bugs in ch341readEEPROM()

### DIFF
--- a/ch341funcs.c
+++ b/ch341funcs.c
@@ -163,7 +163,7 @@ int32_t ch341readEEPROM(struct libusb_device_handle *devHandle, uint8_t *buffer,
 
     uint8_t ch341outBuffer[EEPROM_READ_BULKOUT_BUF_SZ];
     uint8_t ch341inBuffer[IN_BUF_SZ];               // 0x100 bytes
-    int32_t ret = 0, readpktcount;
+    int32_t ret = 0, readpktcount = 0;
     struct libusb_transfer *xferBulkIn, *xferBulkOut;
     struct timeval tv = {0, 100};                   // our async polling interval
 

--- a/ch341funcs.c
+++ b/ch341funcs.c
@@ -204,8 +204,11 @@ int32_t ch341readEEPROM(struct libusb_device_handle *devHandle, uint8_t *buffer,
 		if (ret < 0 || getnextpkt == -1) {          // indicates an error
             fprintf(stderr, "ret from libusb_handle_timeout = %d\n", ret);
             fprintf(stderr, "getnextpkt = %d\n", getnextpkt);
-            fprintf(stderr, "USB read error : %s\n", strerror(-ret));
-			goto out_deinit;
+            if (ret < 0)
+                fprintf(stderr, "USB read error : %s\n", strerror(-ret));
+            libusb_free_transfer(xferBulkIn);
+            libusb_free_transfer(xferBulkOut);
+            return -1;
         }
         if(getnextpkt == 1) {                       // callback function reports a new BULK IN packet received
             getnextpkt = 0;                         //   reset the flag

--- a/ch341funcs.c
+++ b/ch341funcs.c
@@ -197,7 +197,7 @@ int32_t ch341readEEPROM(struct libusb_device_handle *devHandle, uint8_t *buffer,
 
     byteoffset = 0;
 
-    while (byteoffset < bytestoread) {
+    while (1) {
         fprintf(stdout, "Read [%d] of [%d] bytes      \r", byteoffset, bytestoread);
 		ret = libusb_handle_events_timeout(NULL, &tv);
 
@@ -214,13 +214,16 @@ int32_t ch341readEEPROM(struct libusb_device_handle *devHandle, uint8_t *buffer,
             getnextpkt = 0;                         //   reset the flag
             readpktcount++;                         //   increment the read packet counter
             byteoffset += EEPROM_READ_BULKIN_BUF_SZ;
+            if (byteoffset == bytestoread)
+                break;
+
             fprintf(debugout, "\nRe-submitting transfer request to BULK IN endpoint\n");
             libusb_submit_transfer(xferBulkIn);     // re-submit request for next BULK IN packet of EEPROM data
             if(syncackpkt)
                 syncackpkt = 0;
                                                     // if 4th packet received, we are at end of 0x80 byte data block,
                                                     // if it is not the last block, then resubmit request for data
-            if(readpktcount==4 && byteoffset < bytestoread) {
+            if(readpktcount==4) {
                 fprintf(debugout, "\nSubmitting next transfer request to BULK OUT endpoint\n");
                 readpktcount = 0;
 

--- a/mktestimg.c
+++ b/mktestimg.c
@@ -2,11 +2,12 @@
 
 int main(int argc, char **argv)
 {
+    int i, j;
     static char *hex = "\00\x11\x22\x33\x44\x55\x66\x77\x88\x99\xaa\xbb\xcc\xdd\xee\xff";
 
-    for (int j = 0; j < 256/16; j++)
+    for (j = 0; j < 256/16; j++)
 	{
-        for (int i = 0; i < 16; i++)
+        for (i = 0; i < 16; i++)
 		{
             fputc(hex[j%16], stdout);
 		}


### PR DESCRIPTION
1st:

Using uninitialized `readpktcount` variable in comparison causes miss of a submission of BulkOut transfer, that later causes timeout in BulkIn transfer:

```
$ ./ch341eeprom -s 24c64 -r 2.bin
Read [128] of [8192] bytes
cbBulkIn: error : 2
ret from libusb_handle_timeout = 0
getnextpkt = -1
USB read error : Success
Read [8192] bytes from [24c64] EEPROM
Wrote [8192] bytes to file [2.bin]
```

2nd:

Not checking for `byteoffset < bytestoread` at a proper place causes submission of superfluous BulkIn transfer after the last block of data is received:

```
$ ./ch341eeprom -s 24c64 -r 2.bin
Read [8192] bytes from [24c64] EEPROM
Wrote [8192] bytes to file [2.bin]
libusbx: error [do_close] Device handle closed while transfer was still being processed, but the device is still connected as far as we know
libusbx: error [do_close] A cancellation hasn't even been scheduled on the transfer for which the device is closing
```
