### PR TITLE
Add rules for complete access on GNU/Linux

### DIFF
--- a/99-CH341.rules
+++ b/99-CH341.rules
@@ -1,0 +1,3 @@
+/* This file should be copyed on /etc/udev/rules.d on GNU/Linux OS and derived  */
+/* Add permission to all user to have complete acces to eeprom programmer CH341 */
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1a86", ATTRS{idProduct}=="5512", MODE:="0666"

--- a/mktestimg.c
+++ b/mktestimg.c
@@ -33,9 +33,9 @@ int main(int argc, char **argv)
     char chip;
     static char *hex = "\00\x11\x22\x33\x44\x55\x66\x77\x88\x99\xaa\xbb\xcc\xdd\xee\xff";
 
-    printf("Select chip type:\n\na for 24c01\nb for 24c02\nc for 24c04\nd for 24c08\
-            e for 24c16\nf for 24c32\ng for 24c64\nh for 24c128\ni for 24c256\
-            l for 24c512\nm for 24c1024\n\nInsert a letter:");
+    printf("Select chip type:\n\na for 24c01\nb for 24c02\nc for 24c04\nd for 24c08\n"\
+           "e for 24c16\nf for 24c32\ng for 24c64\nh for 24c128\ni for 24c256\n"\
+           "l for 24c512\nm for 24c1024\n\nInsert a letter:");
     scanf("%c",&chip);
     getchar();
 


### PR DESCRIPTION
Hi,
I have correct a little mistake on the menu of mktestimg program,
I have added a udev.rules example for permit to all user to use CH341 chipset on GNU/Linux.
I know you use Mac OS X, but can be useful for other.
Cheers,
Paolo
