### PR TITLE
Read protocol cleanup and other minor cleanups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ test01: default
 	./ch341eeprom -v -s 24c01 -r tmp_random_readed.bin
 	cmp tmp_random.bin tmp_random_readed.bin
 	rm -f tmp_random.bin tmp_random_readed.bin
-	echo "Test 1Kbit/128bytes EEPROM done"
+	@echo "Test 1Kbit/128bytes EEPROM done"
 
 test02: default
 	dd if=/dev/urandom of=tmp_random.bin bs=128 count=2
@@ -22,7 +22,7 @@ test02: default
 	./ch341eeprom -v -s 24c02 -r tmp_random_readed.bin
 	cmp tmp_random.bin tmp_random_readed.bin
 	rm -f tmp_random.bin tmp_random_readed.bin
-	echo "Test 2Kbit/256bytes EEPROM done"
+	@echo "Test 2Kbit/256bytes EEPROM done"
 
 test04: default
 	dd if=/dev/urandom of=tmp_random.bin bs=128 count=4
@@ -30,7 +30,7 @@ test04: default
 	./ch341eeprom -v -s 24c04 -r tmp_random_readed.bin
 	cmp tmp_random.bin tmp_random_readed.bin
 	rm -f tmp_random.bin tmp_random_readed.bin
-	echo "Test 4Kbit/512bytes EEPROM done"
+	@echo "Test 4Kbit/512bytes EEPROM done"
 
 test08: default
 	dd if=/dev/urandom of=tmp_random.bin bs=128 count=8
@@ -38,7 +38,7 @@ test08: default
 	./ch341eeprom -v -s 24c08 -r tmp_random_readed.bin
 	cmp tmp_random.bin tmp_random_readed.bin
 	rm -f tmp_random.bin tmp_random_readed.bin
-	echo "Test 8Kbit/1Kbyte EEPROM done"
+	@echo "Test 8Kbit/1Kbyte EEPROM done"
 
 test16: default
 	dd if=/dev/urandom of=tmp_random.bin bs=128 count=16
@@ -46,7 +46,7 @@ test16: default
 	./ch341eeprom -v -s 24c16 -r tmp_random_readed.bin
 	cmp tmp_random.bin tmp_random_readed.bin
 	rm -f tmp_random.bin tmp_random_readed.bin
-	echo "Test 16Kbit/2Kbyte EEPROM done"
+	@echo "Test 16Kbit/2Kbyte EEPROM done"
 
 test32: default
 	dd if=/dev/urandom of=tmp_random.bin bs=128 count=32
@@ -54,7 +54,7 @@ test32: default
 	./ch341eeprom -v -s 24c32 -r tmp_random_readed.bin
 	cmp tmp_random.bin tmp_random_readed.bin
 	rm -f tmp_random.bin tmp_random_readed.bin
-	echo "Test 32Kbit/4Kbyte EEPROM done"
+	@echo "Test 32Kbit/4Kbyte EEPROM done"
 
 test64: default
 	dd if=/dev/urandom of=tmp_random.bin bs=128 count=64
@@ -62,7 +62,7 @@ test64: default
 	./ch341eeprom -v -s 24c64 -r tmp_random_readed.bin
 	cmp tmp_random.bin tmp_random_readed.bin
 	rm -f tmp_random.bin tmp_random_readed.bin
-	echo "Test 64Kbit/8Kbyte EEPROM done"
+	@echo "Test 64Kbit/8Kbyte EEPROM done"
 
 test128: default
 	dd if=/dev/urandom of=tmp_random.bin bs=128 count=128
@@ -70,7 +70,7 @@ test128: default
 	./ch341eeprom -v -s 24c128 -r tmp_random_readed.bin
 	cmp tmp_random.bin tmp_random_readed.bin
 	rm -f tmp_random.bin tmp_random_readed.bin
-	echo "Test 128Kbit/16Kbyte EEPROM done"
+	@echo "Test 128Kbit/16Kbyte EEPROM done"
 
 test256: default
 	dd if=/dev/urandom of=tmp_random.bin bs=128 count=256
@@ -78,7 +78,7 @@ test256: default
 	./ch341eeprom -v -s 24c256 -r tmp_random_readed.bin
 	cmp tmp_random.bin tmp_random_readed.bin
 	rm -f tmp_random.bin tmp_random_readed.bin
-	echo "Test 256Kbit/32Kbyte EEPROM done"
+	@echo "Test 256Kbit/32Kbyte EEPROM done"
 
 test512: default
 	dd if=/dev/urandom of=tmp_random.bin bs=128 count=512
@@ -86,7 +86,7 @@ test512: default
 	./ch341eeprom -v -s 24c512 -r tmp_random_readed.bin
 	cmp tmp_random.bin tmp_random_readed.bin
 	rm -f tmp_random.bin tmp_random_readed.bin
-	echo "Test 512Kbit/64Kbyte EEPROM done"
+	@echo "Test 512Kbit/64Kbyte EEPROM done"
 
 test1024: default
 	dd if=/dev/urandom of=tmp_random.bin bs=128 count=1024
@@ -94,4 +94,4 @@ test1024: default
 	./ch341eeprom -v -s 24c1024 -r tmp_random_readed.bin
 	cmp tmp_random.bin tmp_random_readed.bin
 	rm -f tmp_random.bin tmp_random_readed.bin
-	echo "Test 1024Kbit/128Kbyte EEPROM done"
+	@echo "Test 1024Kbit/128Kbyte EEPROM done"

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,9 @@
+CC = clang
+CFLAGS = -Wall -O2
+
 default:
-	clang -o ch341eeprom ch341eeprom.c ch341funcs.c -lusb-1.0
-	clang -o mktestimg mktestimg.c
+	$(CC) $(CFLAGS) -o ch341eeprom ch341eeprom.c ch341funcs.c -lusb-1.0
+	$(CC) $(CFLAGS) -o mktestimg mktestimg.c
 
 clean:
 	rm -f ch341eeprom mktestimg
@@ -92,4 +95,3 @@ test1024: default
 	cmp tmp_random.bin tmp_random_readed.bin
 	rm -f tmp_random.bin tmp_random_readed.bin
 	echo "Test 1024Kbit/128Kbyte EEPROM done"
-

--- a/ch341eeprom.h
+++ b/ch341eeprom.h
@@ -363,6 +363,7 @@ const static struct EEPROM eepromlist[] = {
   { 0, 0, 0, 0 }
 };
 
+extern uint8_t *readbuf;
 
 int32_t ch341readEEPROM(struct libusb_device_handle *devHandle, uint8_t *buf, uint32_t bytes, struct EEPROM* eeprom_info);
 int32_t ch341writeEEPROM(struct libusb_device_handle *devHandle, uint8_t *buf, uint32_t bytes, struct EEPROM* eeprom_info);

--- a/ch341funcs.c
+++ b/ch341funcs.c
@@ -31,7 +31,6 @@ extern FILE *debugout, *verbout;
 uint32_t getnextpkt;                            // set by the callback function
 uint32_t syncackpkt;                            // synch / ack flag used by BULK OUT cb function
 uint32_t byteoffset;
-uint8_t *readbuf;
 
 // --------------------------------------------------------------------------
 // ch341configure()
@@ -58,7 +57,7 @@ struct libusb_device_handle *ch341configure(uint16_t vid, uint16_t pid) {
         return NULL;
     }
 
-    
+
 
     #if LIBUSBX_API_VERSION < 0x01000106
         libusb_set_debug(NULL, 3);                  // maximum debug logging level

--- a/ch341funcs.c
+++ b/ch341funcs.c
@@ -168,7 +168,7 @@ void ch341ReadCmdMarshall(uint8_t *buffer, uint32_t addr, struct EEPROM *eeprom_
     *ptr++ = mCH341A_CMD_I2C_STREAM; // 0
     *ptr++ = mCH341A_CMD_I2C_STM_STA; // 1
     // Write address
-    *ptr++ = mCH341A_CMD_I2C_STM_OUT | (*eeprom_info).addr_size+1; // 2: I2C bus adddress + EEPROM address
+    *ptr++ = mCH341A_CMD_I2C_STM_OUT | ((*eeprom_info).addr_size+1); // 2: I2C bus adddress + EEPROM address
     uint8_t msb_addr;
     if ((*eeprom_info).addr_size >= 2) {
         // 24C32 and more
@@ -300,7 +300,6 @@ int32_t ch341readEEPROM(struct libusb_device_handle *devHandle, uint8_t *buffer,
         }
 	}
 
-out_deinit:
     libusb_free_transfer(xferBulkIn);
     libusb_free_transfer(xferBulkOut);
     return 0;

--- a/ch341funcs.c
+++ b/ch341funcs.c
@@ -410,7 +410,7 @@ int32_t ch341writeEEPROM(struct libusb_device_handle *devHandle, uint8_t *buffer
 
         outptr    = ch341outBuffer;
         *outptr++ = mCH341A_CMD_I2C_STREAM;
-        *outptr++ = 0x5a;                           // what is this 0x5a??
+        *outptr++ = mCH341A_CMD_I2C_STM_MS | 10; // Wait 10ms (?)
         *outptr++ = mCH341A_CMD_I2C_STM_END;
 
         ret = libusb_bulk_transfer(devHandle, BULK_WRITE_ENDPOINT, ch341outBuffer, 3, &actuallen, DEFAULT_TIMEOUT);

--- a/mktestimg.c
+++ b/mktestimg.c
@@ -25,6 +25,7 @@
 
 int main(int argc, char **argv)
 {
+    int ret;
 
     FILE *out=fopen( "test.bin", "w" );
     /*create and open file test.bin*/
@@ -36,7 +37,9 @@ int main(int argc, char **argv)
     printf("Select chip type:\n\na for 24c01\nb for 24c02\nc for 24c04\nd for 24c08\n"\
            "e for 24c16\nf for 24c32\ng for 24c64\nh for 24c128\ni for 24c256\n"\
            "l for 24c512\nm for 24c1024\n\nInsert a letter:");
-    scanf("%c",&chip);
+    ret = scanf("%c",&chip);
+    if (ret != 1)
+	return 1;
     getchar();
 
     switch(chip) {	/* switch cycle*/
@@ -87,6 +90,7 @@ int main(int argc, char **argv)
 
         default:
 	printf("Error, wrong letter\n");   /* in the other case*/
+	return 1;
 	break;
                  }
 
@@ -98,7 +102,7 @@ int main(int argc, char **argv)
             /* create a binary file with 'rolling'*/
 		}
 	}
-	
+
         fflush(out);
         fclose(out);
         /* clean and close file test.bin*/
@@ -107,4 +111,3 @@ int main(int argc, char **argv)
 
 	return 0;
 }
-


### PR DESCRIPTION
Tested with an 24c256 eeprom.

# make test256                                 
clang -Wall -O2 -o ch341eeprom ch341eeprom.c ch341funcs.c -lusb-1.0
clang -Wall -O2 -o mktestimg mktestimg.c
dd if=/dev/urandom of=tmp_random.bin bs=128 count=256
256+0 records in
256+0 records out
32768 bytes (33 kB, 32 KiB) copied, 0.00188764 s, 17.4 MB/s
./ch341eeprom -v -s 24c256 -w tmp_random.bin
Searching USB buses for WCH CH341a i2c EEPROM programmer [1a86:5512]
Found [1a86:5512] as device [5] on USB bus [1]
Opened device [1a86:5512]
Claimed device interface [0]
Device reported its revision [4.03]
Configured USB device with vendor ID: 1a86 product ID: 5512
Set i2c bus speed to [100kHz]
Read [32768] bytes from file [tmp_random.bin]
Wrote [32768] bytes to [24c256] EEPROM     
Closed USB device
./ch341eeprom -v -s 24c256 -r tmp_random_readed.bin
Searching USB buses for WCH CH341a i2c EEPROM programmer [1a86:5512]
Found [1a86:5512] as device [5] on USB bus [1]
Opened device [1a86:5512]
Claimed device interface [0]
Device reported its revision [4.03]
Configured USB device with vendor ID: 1a86 product ID: 5512
Set i2c bus speed to [100kHz]
Read [32768] bytes from [24c256] EEPROM
Wrote [32768] bytes to file [tmp_random_readed.bin]
Closed USB device
cmp tmp_random.bin tmp_random_readed.bin
rm -f tmp_random.bin tmp_random_readed.bin
Test 256Kbit/32Kbyte EEPROM done

